### PR TITLE
アラート画面をモーダル画面へ変更

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -11,5 +11,6 @@
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
+    <div id="modal-root"></div>
   </body>
 </html>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,7 +18,7 @@ export const App: React.FC = () => {
   useEffect(() => {
     fetch(refreshTokenUrl, {
       method: 'POST',
-      credentials: 'include'
+      credentials: 'include',
     }).then(() => {
       setLoading(false);
     });

--- a/src/Routes.tsx
+++ b/src/Routes.tsx
@@ -1,18 +1,22 @@
 import React from 'react';
 import { BrowserRouter, Switch, Route } from 'react-router-dom';
+
 import { TodoApp } from './pages/TodoApp';
 import { Register } from './pages/Register';
 import { Landing } from './pages/Landing';
 import { DeleteAccount } from './pages/DeleteAccount';
+import { ModalContext } from './createContext/ModalContext';
 
 export const Routes: React.FC = () => {
   return (
     <BrowserRouter>
       <Switch>
-        <Route exact path="/" component={Landing} />
-        <Route exact path="/home" component={TodoApp} />
-        <Route exact path="/register" component={Register} />
-        <Route exact path="/deleteaccount" component={DeleteAccount} />
+        <ModalContext.Provider value={{ text: undefined, state: false }}>
+          <Route exact path="/" component={Landing} />
+          <Route exact path="/register" component={Register} />
+          <Route exact path="/deleteaccount" component={DeleteAccount} />
+          <Route exact path="/home" component={TodoApp} />
+        </ModalContext.Provider>
       </Switch>
     </BrowserRouter>
   );

--- a/src/components/CreateTodo.tsx
+++ b/src/components/CreateTodo.tsx
@@ -29,14 +29,14 @@ export const CreateTodo: React.FC = () => {
     <form
       className="todo-form"
       autoComplete="off"
-      onSubmit={async event => {
+      onSubmit={async (event) => {
         event.preventDefault();
 
         try {
           await createTodo({
             variables: {
-              title: state.task
-            }
+              title: state.task,
+            },
           });
           state.task = '';
           // エラーの表示を消す
@@ -55,7 +55,7 @@ export const CreateTodo: React.FC = () => {
           name="title"
           placeholder="やること"
           value={state.task}
-          onChange={event => {
+          onChange={(event) => {
             dispatch({ type: 'createTodo', value: event.target.value });
           }}
         />

--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -25,15 +25,16 @@ export const Login: React.FC = () => {
   return (
     <form
       className="login-form"
-      onSubmit={async event => {
+      onSubmit={async (event) => {
         event.preventDefault();
+        console.log(state.email);
 
         try {
           await login({
             variables: {
               email: state.email,
-              password: state.password
-            }
+              password: state.password,
+            },
           });
           history.push('/home');
         } catch {}
@@ -45,7 +46,7 @@ export const Login: React.FC = () => {
           className="login-input"
           placeholder="Eメール"
           value={state.email}
-          onChange={event => {
+          onChange={(event) => {
             dispatch({ type: 'emailType', value: event.target.value });
           }}
         />
@@ -54,7 +55,7 @@ export const Login: React.FC = () => {
           type="password"
           placeholder="パスワード"
           value={state.password}
-          onChange={event => {
+          onChange={(event) => {
             dispatch({ type: 'passwordType', value: event.target.value });
           }}
         />

--- a/src/components/componentStyle/Modal.css
+++ b/src/components/componentStyle/Modal.css
@@ -1,0 +1,51 @@
+#modal-root {
+  position: relative;
+}
+
+.modal {
+  width: 100%;
+  height: 100vh;
+  top: 0;
+  position: fixed;
+  background-color: rgba(0, 0, 0, 0.25);
+}
+
+.modal-container {
+  height: 100%;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.modal-box {
+  width: 30%;
+  height: 30%;
+  border: 5px;
+  border-style: solid;
+  border-radius: 10px;
+  border-color: #fffdf9;
+  background-color: #bfe8f0;
+}
+
+.modal-inner {
+  width: 100%;
+  height: 50%;
+  position: relative;
+}
+
+.modal-text {
+  margin: 0;
+  padding: 50px;
+  text-align: center;
+}
+
+.modal-btn {
+  position: absolute;
+  width: 20%;
+  margin: 0;
+  background-color: #fffdf9;
+  top: 50%;
+  left: 50%;
+  transform: translateY(-50%) translateX(-50%);
+}

--- a/src/components/modal.tsx
+++ b/src/components/modal.tsx
@@ -1,0 +1,50 @@
+import React, { useContext } from 'react';
+import ReactDOM from 'react-dom';
+
+import './componentStyle/Modal.css';
+import { ModalContext } from '../createContext/ModalContext';
+
+interface Props {
+  modalText: string | undefined;
+}
+
+export const Modal: React.FC<Props> = ({ modalText }) => {
+  const modalCtx = useContext(ModalContext);
+
+  const modalRoot = document.getElementById('modal-root');
+  const el = document.createElement('div');
+  if (!modalRoot) {
+    throw new Error('エレメントを取得出来ませんでした。');
+  }
+  // クラス名追加
+  el.className = 'modal';
+  // モーダルルートにdiv要素を追加
+  modalRoot.appendChild(el);
+
+  return (
+    <div>
+      {ReactDOM.createPortal(
+        <div className="modal-container">
+          <div className="modal-box">
+            <div className="modal-inner">
+              <p className="modal-text">{modalText}</p>
+            </div>
+            <div className="modal-inner">
+              <button
+                className="modal-btn"
+                onClick={() => {
+                  //　エレメントを削除し、モーダルを閉じる
+                  modalRoot.removeChild(el);
+                  modalCtx.state = false;
+                }}
+              >
+                OK！
+              </button>
+            </div>
+          </div>
+        </div>,
+        el
+      )}
+    </div>
+  );
+};

--- a/src/createContext/ModalContext.ts
+++ b/src/createContext/ModalContext.ts
@@ -1,0 +1,11 @@
+import { createContext } from 'react';
+
+interface ModalCtx {
+  text: string | undefined;
+  state: boolean | undefined;
+}
+
+export const ModalContext = createContext<ModalCtx>({
+  text: undefined,
+  state: undefined,
+});

--- a/src/pages/DeleteAccount.tsx
+++ b/src/pages/DeleteAccount.tsx
@@ -47,12 +47,12 @@ export const DeleteAccount: React.FC = () => {
                   password: state.password,
                 },
               });
+              // ランディングページでモーダルを表示させる
+              modalCtx.text = 'アカウントを削除しました。';
+              modalCtx.state = true;
+              // ランディングページへ遷移する
+              history.push('/');
             } catch {}
-            // ランディングページでモーダルを表示させる
-            modalCtx.text = 'アカウントを削除しました。';
-            modalCtx.state = true;
-
-            history.push('/');
           }}
         >
           <div className="input-form-inner">

--- a/src/pages/DeleteAccount.tsx
+++ b/src/pages/DeleteAccount.tsx
@@ -1,4 +1,4 @@
-import React, { useReducer } from 'react';
+import React, { useReducer, useContext } from 'react';
 import { useHistory } from 'react-router-dom';
 import _ from 'lodash';
 
@@ -8,6 +8,7 @@ import { loginGqlError } from '../models/loginGqlError';
 import { DeleteAccountButton } from '../components/button/DeleteAccountButton';
 import { Explanation } from '../components/explanation';
 import { formReducer, initialState } from '../store/FormStore';
+import { ModalContext } from '../createContext/ModalContext';
 
 let errorMessage: loginGqlError;
 
@@ -15,6 +16,7 @@ export const DeleteAccount: React.FC = () => {
   const history = useHistory();
   const [deleteAccount, { loading, error }] = useDeleteAccountMutation();
   const [state, dispatch] = useReducer(formReducer, initialState);
+  const modalCtx = useContext(ModalContext);
 
   if (error) {
     // GraphQLErrorを取得
@@ -34,7 +36,7 @@ export const DeleteAccount: React.FC = () => {
         />
         <form
           className="delete-account-form"
-          onSubmit={async event => {
+          onSubmit={async (event) => {
             event.preventDefault();
 
             try {
@@ -42,12 +44,15 @@ export const DeleteAccount: React.FC = () => {
                 variables: {
                   nickname: state.nickName,
                   email: state.email,
-                  password: state.password
-                }
+                  password: state.password,
+                },
               });
-              window.alert('アカウントを削除しました。');
-              history.push('/');
             } catch {}
+            // ランディングページでモーダルを表示させる
+            modalCtx.text = 'アカウントを削除しました。';
+            modalCtx.state = true;
+
+            history.push('/');
           }}
         >
           <div className="input-form-inner">
@@ -60,7 +65,7 @@ export const DeleteAccount: React.FC = () => {
               className="form-input"
               value={state.nickName}
               placeholder="ニックネーム"
-              onChange={event => {
+              onChange={(event) => {
                 dispatch({ type: 'nickNameType', value: event.target.value });
               }}
             />
@@ -68,7 +73,7 @@ export const DeleteAccount: React.FC = () => {
               className="form-input"
               value={state.email}
               placeholder="Eメール"
-              onChange={event => {
+              onChange={(event) => {
                 dispatch({ type: 'emailType', value: event.target.value });
               }}
             />
@@ -77,7 +82,7 @@ export const DeleteAccount: React.FC = () => {
               type="password"
               value={state.password}
               placeholder="パスワード"
-              onChange={event => {
+              onChange={(event) => {
                 dispatch({ type: 'passwordType', value: event.target.value });
               }}
             />

--- a/src/pages/Landing.tsx
+++ b/src/pages/Landing.tsx
@@ -1,11 +1,14 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { useHistory } from 'react-router-dom';
-import './pageStyle/Landing.css';
 
+import './pageStyle/Landing.css';
 import { Login } from '../components/Login';
+import { Modal } from '../components/modal';
+import { ModalContext } from '../createContext/ModalContext';
 
 export const Landing: React.FC = () => {
   const history = useHistory();
+  const modalCtx = useContext(ModalContext);
   return (
     <div className="main">
       <div className="main-container">
@@ -31,6 +34,7 @@ export const Landing: React.FC = () => {
           </div>
         </div>
       </div>
+      {modalCtx.state ? <Modal modalText={modalCtx.text} /> : undefined}
     </div>
   );
 };

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -42,7 +42,6 @@ export const Register: React.FC = () => {
       }
     }
   }
-
   return (
     <div className="main">
       <div className="register-wrapper">
@@ -70,12 +69,12 @@ export const Register: React.FC = () => {
                   password: state.password,
                 },
               });
+              // ランディングページでモーダルを表示させる
+              modalCtx.text = '登録完了しました！ログインしてください！';
+              modalCtx.state = true;
+              // ランディングページに遷移する
+              history.push('/');
             } catch {}
-            // ランディングページでモーダルを表示させる
-            modalCtx.text = '登録完了しました！ログインしてください！';
-            modalCtx.state = true;
-
-            history.push('/');
           }}
         >
           <div className="input-form-inner">

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -1,4 +1,4 @@
-import React, { useReducer } from 'react';
+import React, { useReducer, useContext } from 'react';
 import _ from 'lodash';
 
 import './pageStyle/Register.css';
@@ -8,6 +8,7 @@ import { RegisterButton } from '../components/button/RegisterButton';
 import { RegisterGqlError, ConstraintsError } from '../models/registerGqlError';
 import { Explanation } from '../components/explanation';
 import { formReducer, initialState } from '../store/FormStore';
+import { ModalContext } from '../createContext/ModalContext';
 
 let nickNameError: string | undefined;
 let emailError: string | undefined;
@@ -18,6 +19,7 @@ export const Register: React.FC = () => {
   const history = useHistory();
   const [register, { loading, error }] = useRegisterMutation();
   const [state, dispatch] = useReducer(formReducer, initialState);
+  const modalCtx = useContext(ModalContext);
 
   if (error) {
     // GraphQLErrorを取得
@@ -53,7 +55,7 @@ export const Register: React.FC = () => {
         />
         <form
           className="register-form"
-          onSubmit={async event => {
+          onSubmit={async (event) => {
             event.preventDefault();
             // エラーメッセージをリセット
             nickNameError = undefined;
@@ -65,11 +67,14 @@ export const Register: React.FC = () => {
                 variables: {
                   nickname: state.nickName,
                   email: state.email,
-                  password: state.password
-                }
+                  password: state.password,
+                },
               });
             } catch {}
-            window.alert('登録完了！　ログインしてください!');
+            // ランディングページでモーダルを表示させる
+            modalCtx.text = '登録完了しました！ログインしてください！';
+            modalCtx.state = true;
+
             history.push('/');
           }}
         >
@@ -79,7 +84,7 @@ export const Register: React.FC = () => {
               className="form-input"
               value={state.nickName}
               placeholder="ニックネーム"
-              onChange={event => {
+              onChange={(event) => {
                 dispatch({ type: 'nickNameType', value: event.target.value });
               }}
             />
@@ -88,7 +93,7 @@ export const Register: React.FC = () => {
               className="form-input"
               value={state.email}
               placeholder="Eメール"
-              onChange={event => {
+              onChange={(event) => {
                 dispatch({ type: 'emailType', value: event.target.value });
               }}
             />
@@ -98,7 +103,7 @@ export const Register: React.FC = () => {
               type="password"
               value={state.password}
               placeholder="パスワード"
-              onChange={event => {
+              onChange={(event) => {
                 dispatch({ type: 'passwordType', value: event.target.value });
               }}
             />

--- a/src/pages/TodoApp.tsx
+++ b/src/pages/TodoApp.tsx
@@ -8,7 +8,7 @@ import { HelloUser } from '../components/HelloUser';
 
 export const TodoApp: React.FC = () => {
   const { data, loading, error } = useGetTodoListQuery({ pollInterval: 500 });
-  const meData = useMeQuery();
+  const meData = useMeQuery({ pollInterval: 500 });
 
   return (
     <div>

--- a/src/store/FormStore.ts
+++ b/src/store/FormStore.ts
@@ -14,7 +14,7 @@ export const initialState: StateInput = {
   nickName: '',
   email: '',
   password: '',
-  task: ''
+  task: '',
 };
 
 //　フォームを送信するのに必要な値の状態管理


### PR DESCRIPTION
新規登録、アカウント削除時に表示されるアラート画面をモーダル画面へと変更し、UIを改善。
同時に、エラー画面をスルーしてモーダル画面に遷移するバグを修正。